### PR TITLE
Be more robust against bad UTF-8 in show engine innodb status output

### DIFF
--- a/gemfiles/Gemfile.rails3
+++ b/gemfiles/Gemfile.rails3
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem "codeclimate-test-reporter", group: :test, require: nil
 gem "activerecord", '~>3.1.0'
+gem "mysql2", '~>0.3.21'
 
 # Specify your gem's dependencies in cleansweep.gemspec
 gemspec path: '..'

--- a/lib/clean_sweep/purge_runner/mysql_status.rb
+++ b/lib/clean_sweep/purge_runner/mysql_status.rb
@@ -76,6 +76,16 @@ class CleanSweep::PurgeRunner::MysqlStatus
         show engine innodb status
     EOF
     status_string = rows.first[2]
+
+    # This output of 'show engine innnodb status' contains a bunch of
+    # information, including info about the most recently detected deadlock,
+    # which has the involved queries, which may contain invalid UTF-8 byte
+    # sequences.
+    #
+    # Forcing the encoding to ASCII-8BIT here prevents the regex match below
+    # from falling over when this happens.
+    status_string.force_encoding('ASCII-8BIT')
+
     return /History list length ([0-9]+)/.match(status_string)[1].to_i
   end
 


### PR DESCRIPTION
We're running into an issue where the output of `show engine innodb status` sometimes contains invalid UTF-8 byte sequences, which then cause `get_history_list` to fall over while trying to parse the history list from this output using a regex.

This isn't consistently reproducible, but I'm theorizing that it happens sometimes because the `show engine innodb status` contains user-supplied values in the form of the information about the most recent deadlock (it shows the raw queries that were involved in the deadlock). When those queries happen to contain invalid UTF-8 byte sequences, we hit this issue, which causes the whole purge job to bail out.

In such cases, forcing the encoding to `ASCII-8BIT` allows the regex match to still work and extract the history list length, and avoids the purge job failing.
