### PR TITLE
Reconnect to MySQL automatically if connection is dropped during a purge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ gemfile:
 addons:
   code_climate:
     repo_token: 7ec6fd701b7d2b206cdd233c2202b6e11c8ba6af01f8a93f5e24595008ac20a0
+after_success:
+  - bundle exec codeclimate-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
   - 2.1.4
-  - 1.9.3
 gemfile:
   - gemfiles/Gemfile.rails3
   - gemfiles/Gemfile.rails4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,9 @@
 See the [documentation](http://bkayser.github.io/cleansweep) for details
+### Version 1.1.0
+
+* Support automatic DB reconnection during a purge run.
+  The max number of reconnections can be controlled with the max_reconnects
+  option to PurgeRunner.
 
 ### Version 1.0.6
 

--- a/cleansweep.gemspec
+++ b/cleansweep.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'activerecord', '>= 3.0'
+  spec.add_runtime_dependency 'activerecord', '>= 3.0', '< 5.0.0'
   spec.add_runtime_dependency 'newrelic_rpm'
   spec.add_runtime_dependency 'mysql2', '~> 0.3'
 

--- a/lib/clean_sweep/purge_runner.rb
+++ b/lib/clean_sweep/purge_runner.rb
@@ -99,6 +99,8 @@ class CleanSweep::PurgeRunner
 
     @max_history      = options[:max_history]
     @max_repl_lag     = options[:max_repl_lag]
+    @max_reconnects   = options[:max_reconnects] || 3
+    @reconnects_remaining = @max_reconnects
 
     @copy_mode        = @target_model && options[:copy_only]
 
@@ -136,6 +138,27 @@ class CleanSweep::PurgeRunner
     @copy_mode
   end
 
+  def with_reconnect_handling
+    begin
+      yield
+    rescue ActiveRecord::StatementInvalid => e
+      if e.message =~ /Lost connection to MySQL server during query/
+        if @reconnects_remaining > 0
+          @reconnects_remaining -= 1
+          wait_before_reconnect = rand * 10.0
+          log :warn, "Lost connection to DB during query, reconnecting and trying again in #{wait_before_reconnect} seconds. #{@reconnects_remaining} re-connection attempts remaining after this. Original error: #{e}"
+          sleep(wait_before_reconnect)
+          @model.connection.reconnect!
+        else
+          log :error, "Lost connection to MySQL during query, and have already reconnected #{@max_reconnects} times. Giving up. Original error: #{e}"
+          raise
+        end
+      else
+        raise
+      end
+    end
+  end
+
   # Execute the purge in chunks according to the parameters given on instance creation.
   # Will raise <tt>CleanSweep::PurgeStopped</tt> if a <tt>stop_after</tt> option was provided and
   # that limit is hit.
@@ -165,6 +188,7 @@ class CleanSweep::PurgeRunner
     rows = NewRelic::Agent.with_database_metric_name(@model.name, 'SELECT') do
       @model.connection.select_rows @query.to_sql
     end
+
     while rows.any? && (!@stop_after || @total_deleted < @stop_after) do
 #      index_entrypoint_args = Hash[*@source_keys.zip(rows.last).flatten]
       log :debug, "#{verb} #{rows.size} records between #{rows.first.inspect} and #{rows.last.inspect}" if @logger.level == Logger::DEBUG
@@ -180,24 +204,30 @@ class CleanSweep::PurgeRunner
         statement = @table_schema.delete_statement(rows)
       end
       log :debug, statement if @logger.level == Logger::DEBUG
-      chunk_deleted = NewRelic::Agent.with_database_metric_name((@target_model||@model), metric_op_name) do
-        (@target_model||@model).connection.update statement
+
+      with_reconnect_handling do
+        chunk_deleted = NewRelic::Agent.with_database_metric_name((@target_model||@model), metric_op_name) do
+          (@target_model||@model).connection.update statement
+        end
+
+        @total_deleted += chunk_deleted
+        raise CleanSweep::PurgeStopped.new("stopped after #{verb} #{@total_deleted} #{@model} records", @total_deleted) if stopped
+        q = @table_schema.scope_to_next_chunk(@query, last_row).to_sql
+        log :debug, "find rows: #{q}" if @logger.level == Logger::DEBUG
+
+        sleep @sleep if @sleep && !copy_mode?
+        @mysql_status.check! if @mysql_status
+
+        rows = NewRelic::Agent.with_database_metric_name(@model, 'SELECT') do
+          @model.connection.select_rows(q)
+        end
       end
 
-      @total_deleted += chunk_deleted
-      raise CleanSweep::PurgeStopped.new("stopped after #{verb} #{@total_deleted} #{@model} records", @total_deleted) if stopped
-      q = @table_schema.scope_to_next_chunk(@query, last_row).to_sql
-      log :debug, "find rows: #{q}" if @logger.level == Logger::DEBUG
-
-      sleep @sleep if @sleep && !copy_mode?
-      @mysql_status.check! if @mysql_status
-
-      rows = NewRelic::Agent.with_database_metric_name(@model, 'SELECT') do
-        @model.connection.select_rows(q)
-      end
       report
     end
+
     report(true)
+
     if copy_mode?
       log :info,  "completed after #{verb} #{@total_deleted} #{@table_schema.name} records to #{@target_model.table_name}"
     else

--- a/lib/clean_sweep/purge_runner.rb
+++ b/lib/clean_sweep/purge_runner.rb
@@ -74,6 +74,10 @@ require 'stringio'
 # [:max_repl_lag]
 #    The maximum length of the replication lag.  Checked every 5 minutes and if exceeded the purge
 #    pauses until the replication lag is below 90% of this value.
+# [:max_reconnects]
+#    The maximum number of times to automatically attempt to reconnect to the database
+#    in the event of a dropped connection during a query. Set this to zero if you want
+#    to opt-out of the automatic reconnect behavior. Default: 3.
 
 class CleanSweep::PurgeRunner
 

--- a/lib/clean_sweep/version.rb
+++ b/lib/clean_sweep/version.rb
@@ -1,3 +1,3 @@
 module CleanSweep
-  VERSION = "1.0.6"
+  VERSION = "1.1.0"
 end

--- a/spec/purge_runner_spec.rb
+++ b/spec/purge_runner_spec.rb
@@ -234,12 +234,16 @@ describe CleanSweep::PurgeRunner::MysqlStatus do
     it "fetches innodb status" do
       mysql_status.get_replication_lag
     end
+
     it "checks history and pauses" do
       allow(mysql_status).to receive(:get_history_length).and_return(101, 95, 89)
+      allow(mysql_status).to receive(:get_replication_lag).and_return(50)
       expect(mysql_status).to receive(:pause).twice
       mysql_status.check!
     end
+
     it "checks replication and pauses" do
+      allow(mysql_status).to receive(:get_history_length).and_return(50)
       allow(mysql_status).to receive(:get_replication_lag).and_return(101, 95, 89)
       expect(mysql_status).to receive(:pause).twice
       mysql_status.check!

--- a/spec/purge_runner_spec.rb
+++ b/spec/purge_runner_spec.rb
@@ -7,6 +7,7 @@ describe CleanSweep::PurgeRunner do
     before do
       Timecop.freeze Time.parse("2014-12-02 13:47:43.000000 -0800")
     end
+
     after do
       Timecop.return
     end
@@ -135,6 +136,82 @@ EOF
         Book.delete_all
       end
 
+      it 'reconnects after a lost connection' do
+        purger = CleanSweep::PurgeRunner.new model: Book,
+                                             chunk_size: 10
+
+        original_update = Book.connection.method(:update)
+        update_number = 0
+
+        allow(Book.connection).to receive(:update) do |*args|
+          update_number += 1
+
+          if update_number == 2
+            raise ActiveRecord::StatementInvalid.new("Lost connection to MySQL server during query: blah blah")
+          else
+            original_update.call(*args)
+          end
+        end
+
+        expect(purger).to receive(:sleep).once
+        expect(Book.connection).to receive(:reconnect!).once
+
+        purger.execute_in_batches
+
+        expect(Book.count).to eq(0)
+      end
+
+      it 'reconnects after a lost connection during select' do
+        purger = CleanSweep::PurgeRunner.new model: Book,
+                                             chunk_size: 10
+
+        original_select_rows = Book.connection.method(:select_rows)
+        iteration = 0
+
+        allow(Book.connection).to receive(:select_rows) do |*args|
+          iteration += 1
+
+          if iteration == 2
+            raise ActiveRecord::StatementInvalid.new("Lost connection to MySQL server during query: blah blah")
+          else
+            original_select_rows.call(*args)
+          end
+        end
+
+        expect(purger).to receive(:sleep).once
+        expect(Book.connection).to receive(:reconnect!).once
+
+        purger.execute_in_batches
+
+        expect(Book.count).to eq(0)
+      end
+
+      it 'stops trying to reconnect after max_reconnects' do
+        purger = CleanSweep::PurgeRunner.new model: Book,
+                                             chunk_size: 10,
+                                             max_reconnects: 4
+
+        original_update = Book.connection.method(:update)
+        update_number = 0
+
+        allow(Book.connection).to receive(:update) do |*args|
+          update_number += 1
+          if update_number > 1
+            raise ActiveRecord::StatementInvalid.new("Lost connection to MySQL server during query: blah blah")
+          else
+            original_update.call(*args)
+          end
+        end
+
+        expect(purger).to receive(:sleep).exactly(4).times
+        expect(Book.connection).to receive(:reconnect!).exactly(4).times
+
+        expect { purger.execute_in_batches }.to raise_error(ActiveRecord::StatementInvalid)
+
+        # we only got through the first batch of 10, and then gave up
+        expect(Book.count).to eq(40)
+      end
+
       it 'waits for history' do
         purger = CleanSweep::PurgeRunner.new model: Book,
                                              max_history: 100,
@@ -209,10 +286,11 @@ EOF
         count = purger.execute_in_batches
         expect(count).to be(@total_book_size)
         expect(BookTemp.count).to eq(@total_book_size)
-        last_book = BookTemp.last
-        expect(last_book.book_id).to be 200
-        expect(last_book.bin).to be 2000
-        expect(last_book.published_by).to eq 'Random House'
+        last_book = Book.last
+        last_book_copy = BookTemp.last
+        expect(last_book_copy.book_id).to eq(last_book.id)
+        expect(last_book_copy.bin).to eq(last_book.bin)
+        expect(last_book_copy.published_by).to eq(last_book.publisher)
       end
 
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,8 @@
 ENV['RACK_ENV'] = 'test'
 
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+require 'simplecov'
+SimpleCov.start
+
 require 'clean_sweep'
 require 'factory_girl'
 require 'fileutils'


### PR DESCRIPTION
We've been seeing consistent issues wherein the connection to MySQL is lost during the course of an invocation of `PurgeRunner#execute_in_batches` (sometimes in the `#update` calls, and sometimes in `#select_rows`).

This change adds a `:max_reconnects` option to `PurgeRunner` that controls how many times it should automatically attempt to re-connect to the MySQL server before giving up, which hopefully will improve the reliability of the purges we're running. The new option defaults to a value of 3.

Before reconnecting, the `PurgeRunner` will sleep for a randomized amount of time between 0 and 10 seconds in order to give the network / DB some time to recover.

I've also bumped the version number up to 1.1.0 in light of this new feature.